### PR TITLE
커피챗 로직 수정 - Feat/#213/endermaru

### DIFF
--- a/src/main/kotlin/com/wafflestudio/internhasha/applicant/dto/ApplicantResponse.kt
+++ b/src/main/kotlin/com/wafflestudio/internhasha/applicant/dto/ApplicantResponse.kt
@@ -20,7 +20,7 @@ data class ApplicantResponse(
     val explanation: String? = null,
     val stacks: List<String>? = null,
     val imageKey: String? = null,
-    val cvKey: String? = null,
+    val cvKey: String,
     val portfolioKey: String? = null,
     val links: List<Link>? = null,
 ) {

--- a/src/main/kotlin/com/wafflestudio/internhasha/applicant/dto/PutApplicantRequest.kt
+++ b/src/main/kotlin/com/wafflestudio/internhasha/applicant/dto/PutApplicantRequest.kt
@@ -22,8 +22,9 @@ data class PutApplicantRequest(
         >? = null,
     @field:Size(max = 512, message = "imageKey cannot be more than 512 characters")
     val imageKey: String? = null,
+    @field:NotNull(message = "cvKey is required")
     @field:Size(max = 512, message = "cvKey cannot be more than 512 characters")
-    val cvKey: String? = null,
+    val cvKey: String,
     @field:Size(max = 512, message = "portfolioKey cannot be more than 512 characters")
     val portfolioKey: String? = null,
     @field:Size(max = 5, message = "the number of links cannot be more than 5")

--- a/src/main/kotlin/com/wafflestudio/internhasha/applicant/persistence/ApplicantEntity.kt
+++ b/src/main/kotlin/com/wafflestudio/internhasha/applicant/persistence/ApplicantEntity.kt
@@ -48,7 +48,7 @@ class ApplicantEntity(
     @Column(name = "profile_image_key")
     var profileImageKey: String? = null,
     @Column(name = "cv_key")
-    var cvKey: String? = null,
+    var cvKey: String,
     @Column(name = "portfolio_key")
     var portfolioKey: String? = null,
     @Column(name = "links", length = 10500)

--- a/src/main/kotlin/com/wafflestudio/internhasha/applicant/service/ApplicantService.kt
+++ b/src/main/kotlin/com/wafflestudio/internhasha/applicant/service/ApplicantService.kt
@@ -66,7 +66,7 @@ class ApplicantService(
         // 기존 s3 object 삭제
 
         applicantEntity?.let { applicant ->
-            applicant.cvKey?.let { if (it != request.cvKey) s3Service.deleteS3File(it) }
+            applicant.cvKey.let { if (it != request.cvKey) s3Service.deleteS3File(it) }
             applicant.profileImageKey?.let { if (it != request.imageKey) s3Service.deleteS3File(it) }
             applicant.portfolioKey?.let { if (it != request.portfolioKey) s3Service.deleteS3File(it) }
         }

--- a/src/main/kotlin/com/wafflestudio/internhasha/auth/service/AuthService.kt
+++ b/src/main/kotlin/com/wafflestudio/internhasha/auth/service/AuthService.kt
@@ -286,7 +286,7 @@ class AuthService(
 
         // s3 object 삭제
         userEntity.applicant?.let { applicant ->
-            applicant.cvKey?.let { s3Service.deleteS3File(it) }
+            applicant.cvKey.let { s3Service.deleteS3File(it) }
             applicant.profileImageKey?.let { s3Service.deleteS3File(it) }
             applicant.portfolioKey?.let { s3Service.deleteS3File(it) }
         }

--- a/src/main/kotlin/com/wafflestudio/internhasha/coffeeChat/dto/CoffeeChatDetail.kt
+++ b/src/main/kotlin/com/wafflestudio/internhasha/coffeeChat/dto/CoffeeChatDetail.kt
@@ -73,6 +73,7 @@ data class CoffeeChatCompany(
                         updatedAt = entity.applicant.updatedAt,
                         userRole = entity.applicant.userRole,
                         email = entity.applicant.email,
+                        cvKey = entity.applicant.applicant?.cvKey?: "",
                     )
 
             // 성사 조건에 따라 이메일 필터링

--- a/src/main/kotlin/com/wafflestudio/internhasha/coffeeChat/dto/CoffeeChatDetail.kt
+++ b/src/main/kotlin/com/wafflestudio/internhasha/coffeeChat/dto/CoffeeChatDetail.kt
@@ -2,6 +2,7 @@ package com.wafflestudio.internhasha.coffeeChat.dto
 
 import com.wafflestudio.internhasha.applicant.dto.ApplicantResponse
 import com.wafflestudio.internhasha.coffeeChat.CoffeeChatStatus
+import com.wafflestudio.internhasha.coffeeChat.CoffeeChatUserForbiddenException
 import com.wafflestudio.internhasha.coffeeChat.persistence.CoffeeChatEntity
 import java.time.LocalDateTime
 
@@ -66,14 +67,8 @@ data class CoffeeChatCompany(
         ): CoffeeChatCompany {
             val applicantResponse =
                 entity.applicant.applicant?.let { ApplicantResponse.fromEntity(it) }
-                    ?: ApplicantResponse(
-                        id = entity.applicant.id,
-                        name = entity.applicant.name,
-                        createdAt = entity.applicant.createdAt,
-                        updatedAt = entity.applicant.updatedAt,
-                        userRole = entity.applicant.userRole,
-                        email = entity.applicant.email,
-                        cvKey = entity.applicant.applicant?.cvKey?: "",
+                    ?: throw CoffeeChatUserForbiddenException(
+                        details = mapOf("applicantId" to entity.applicant.id, "user.applicant" to "No Profile"),
                     )
 
             // 성사 조건에 따라 이메일 필터링

--- a/src/main/kotlin/com/wafflestudio/internhasha/coffeeChat/service/CoffeeChatService.kt
+++ b/src/main/kotlin/com/wafflestudio/internhasha/coffeeChat/service/CoffeeChatService.kt
@@ -279,7 +279,7 @@ class CoffeeChatService(
 
         // changed == true 인 것만 비동기로 업데이트
         coffeeChatUpdateService.updateChangedFlagsAsync(
-            coffeeChatEntityList.filter { it.changed }
+            coffeeChatEntityList.filter { it.changed },
         )
 
         return ret

--- a/src/main/kotlin/com/wafflestudio/internhasha/coffeeChat/service/CoffeeChatService.kt
+++ b/src/main/kotlin/com/wafflestudio/internhasha/coffeeChat/service/CoffeeChatService.kt
@@ -70,6 +70,11 @@ class CoffeeChatService(
         val coffeeChatEntity = getCoffeeChatEntity(coffeeChatId)
         // 작성자가 아니면 403
         checkCoffeeChatAuthority(coffeeChatEntity, user, UserRole.APPLICANT)
+
+        if (coffeeChatEntity.changed) {
+            coffeeChatUpdateService.updateChangedFlagsAsync(listOf(coffeeChatEntity))
+        }
+
         return CoffeeChatApplicant.fromEntity(coffeeChatEntity)
     }
 
@@ -260,7 +265,6 @@ class CoffeeChatService(
         )
     }
 
-    @Transactional
     fun getCoffeeChatListApplicant(
         user: User,
     ): List<CoffeeChatBrief> {

--- a/src/main/kotlin/com/wafflestudio/internhasha/coffeeChat/service/CoffeeChatUpdateService.kt
+++ b/src/main/kotlin/com/wafflestudio/internhasha/coffeeChat/service/CoffeeChatUpdateService.kt
@@ -10,7 +10,6 @@ import org.springframework.transaction.annotation.Transactional
 class CoffeeChatUpdateService(
     private val coffeeChatRepository: CoffeeChatRepository,
 ) {
-
     @Async
     @Transactional
     fun updateChangedFlagsAsync(changedList: List<CoffeeChatEntity>) {

--- a/src/main/kotlin/com/wafflestudio/internhasha/coffeeChat/service/CoffeeChatUpdateService.kt
+++ b/src/main/kotlin/com/wafflestudio/internhasha/coffeeChat/service/CoffeeChatUpdateService.kt
@@ -1,0 +1,22 @@
+package com.wafflestudio.internhasha.coffeeChat.service
+
+import com.wafflestudio.internhasha.coffeeChat.persistence.CoffeeChatEntity
+import com.wafflestudio.internhasha.coffeeChat.persistence.CoffeeChatRepository
+import org.springframework.scheduling.annotation.Async
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+@Service
+class CoffeeChatUpdateService(
+    private val coffeeChatRepository: CoffeeChatRepository,
+) {
+
+    @Async
+    @Transactional
+    fun updateChangedFlagsAsync(changedList: List<CoffeeChatEntity>) {
+        changedList.forEach {
+            it.changed = false
+            coffeeChatRepository.save(it)
+        }
+    }
+}


### PR DESCRIPTION
### 📝 작업 내용

- cvKey를 필수로 설정(entity, DTO)
- 커피챗 작성 시 user.applicant가 null이 아닌지 확인(프로필 작성 여부를 서버에서 재확인)
- 마이페이지의 커피챗 리스트 확인 외에도 상세 커피챗 확인 시 지원자의 읽음(isChanged) 여부를 false로 전환 = 읽었음으로 체크
- 읽었음에 대한 비동기 처리를 위한 서비스 추가
- close #213 

### 📸 스크린샷 (선택)

### 🚀 리뷰 요구사항 (선택)

- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요.
