### PR TITLE
POST /api/mail/verify 에 중복 메일 검증 추가 & Post 기본 정렬 공고 생성순(과거순) 변경

### DIFF
--- a/src/main/kotlin/com/wafflestudio/internhasha/auth/service/AuthService.kt
+++ b/src/main/kotlin/com/wafflestudio/internhasha/auth/service/AuthService.kt
@@ -220,6 +220,12 @@ class AuthService(
 
     // Email verification
     fun sendSnuMailVerification(request: SnuMailRequest) {
+        if (userRepository.existsByEmail(request.snuMail)) {
+            throw UserDuplicateSnuMailException(
+                details = mapOf("email" to request.snuMail),
+            )
+        }
+
         val emailCode = (100000..999999).random().toString()
         val encryptedEmailCode = BCrypt.hashpw(emailCode, BCrypt.gensalt())
 

--- a/src/main/kotlin/com/wafflestudio/internhasha/post/persistence/PositionSpecification.kt
+++ b/src/main/kotlin/com/wafflestudio/internhasha/post/persistence/PositionSpecification.kt
@@ -177,8 +177,8 @@ class PositionSpecification {
                     orderList.add(criteriaBuilder.desc(closedSort)) // 마감된 건 내림차순
                 }
                 else -> {
-                    // 최신순 정렬 (updatedAt 기준)
-                    orderList.add(criteriaBuilder.desc(root.get<LocalDateTime>("updatedAt")))
+                    // 공고 생성순 정렬 (createdAt 기준)
+                    orderList.add(criteriaBuilder.desc(root.get<LocalDateTime>("createdAt")))
                 }
             }
 

--- a/src/main/kotlin/com/wafflestudio/internhasha/post/persistence/PositionSpecification.kt
+++ b/src/main/kotlin/com/wafflestudio/internhasha/post/persistence/PositionSpecification.kt
@@ -178,7 +178,7 @@ class PositionSpecification {
                 }
                 else -> {
                     // 공고 생성순 정렬 (createdAt 기준)
-                    orderList.add(criteriaBuilder.desc(root.get<LocalDateTime>("createdAt")))
+                    orderList.add(criteriaBuilder.asc(root.get<LocalDateTime>("createdAt")))
                 }
             }
 


### PR DESCRIPTION
### 📝 작업 내용

- 회원가입 용 이메일 인증 메일 전송 요청 api에 기존 유저 중복 테스트를 추가합니다. 중복회원이 있으면 USER_001 (409 Conflict) Error를 반환하고 메일을 발송하지 않습니다.
- 공고 정렬을 과거 생성된 순으로 변경합니다.
- close #221 

### 📸 스크린샷 (선택)

### 🚀 리뷰 요구사항 (선택)

- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요.
